### PR TITLE
Potential fix for code scanning alert no. 1: URL redirection from remote source

### DIFF
--- a/app/auth/views.py
+++ b/app/auth/views.py
@@ -48,9 +48,10 @@ class LoginView(MethodView):
             login_user(user, remember=form.remember_me.data)
             user.update_last_login()
 
-            next_page = request.args.get('next')
-            if not next_page or url_parse(next_page).netloc != '':
-                next_page = url_for('items.all_events')
+            next_page = request.args.get('next', '')
+            next_page = next_page.replace('\\', '')  # Remove backslashes
+            if not next_page or url_parse(next_page).netloc != '' or url_parse(next_page).scheme:
+                next_page = url_for('items.all_events')  # Default to a safe fallback
 
             return redirect(next_page)
 


### PR DESCRIPTION
Potential fix for [https://github.com/hveda/mail-scheduler/security/code-scanning/1](https://github.com/hveda/mail-scheduler/security/code-scanning/1)

To fix the issue, we will enhance the validation of the `next_page` parameter. Specifically, we will:
1. Replace backslashes (`\`) with empty strings to prevent browsers from interpreting them as valid path separators.
2. Use the `url_parse` function to ensure that `next_page` is a relative URL (i.e., it has no scheme or netloc).
3. If the validation fails, default to a safe fallback URL (e.g., the home page or a predefined internal route).

This approach ensures that only safe, relative URLs are used for redirection, mitigating the risk of open redirect vulnerabilities.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
