### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI/CD Pipeline
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/hveda/mail-scheduler/security/code-scanning/7](https://github.com/hveda/mail-scheduler/security/code-scanning/7)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the permissions required. Since the workflow primarily interacts with repository contents (e.g., checking out code), we will set `contents: read` as the minimal required permission. This ensures that no unnecessary write permissions are granted.

The `permissions` block will be added at the top level of the workflow, just below the `name` field, so it applies to all jobs in the workflow. This approach avoids redundancy and ensures consistency across jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
