### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/scheduled-tests.yml
+++ b/.github/workflows/scheduled-tests.yml
@@ -1,5 +1,9 @@
 name: Scheduled Tests
 
+permissions:
+  contents: read
+  statuses: write
+
 on:
   schedule:
     # Run weekly on Sunday at 1:00 AM UTC


### PR DESCRIPTION
Potential fix for [https://github.com/hveda/mail-scheduler/security/code-scanning/6](https://github.com/hveda/mail-scheduler/security/code-scanning/6)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function correctly. Based on the workflow's operations, the following permissions are needed:
- `contents: read` to allow the workflow to read repository contents.
- `statuses: write` to allow the workflow to update commit statuses (e.g., for test results or coverage reports).

The `permissions` block will be added at the top level of the workflow, ensuring it applies to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
