### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,5 +1,8 @@
 name: Build Documentation
 
+permissions:
+  contents: write
+
 on:
   push:
     branches: [ main, master ]


### PR DESCRIPTION
Potential fix for [https://github.com/hveda/mail-scheduler/security/code-scanning/5](https://github.com/hveda/mail-scheduler/security/code-scanning/5)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function correctly. Based on the workflow's steps:
- `contents: read` is needed to check out the repository.
- `contents: write` is required to upload the documentation artifact.

We will add the following `permissions` block:
```yaml
permissions:
  contents: write
```

This ensures the workflow has only the necessary permissions to perform its tasks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
