### PR TITLE
Potential fix for code scanning alert no. 1: URL redirection from remote source

### DIFF
--- a/app/auth/views.py
+++ b/app/auth/views.py
@@ -49,8 +49,8 @@ class LoginView(MethodView):
             user.update_last_login()
 
             next_page = request.args.get('next', '')
-            next_page = next_page.replace('\\', '')  # Remove backslashes
-            if not next_page or url_parse(next_page).netloc != '' or url_parse(next_page).scheme:
+            allowed_paths = ['/items/all_events', '/items/some_other_page']  # Whitelist of allowed paths
+            if next_page not in allowed_paths:
                 next_page = url_for('items.all_events')  # Default to a safe fallback
 
             return redirect(next_page)


### PR DESCRIPTION
Potential fix for [https://github.com/hveda/mail-scheduler/security/code-scanning/1](https://github.com/hveda/mail-scheduler/security/code-scanning/1)

To fix the issue, we will enhance the validation of the `next_page` variable to ensure it is safe for redirection. Specifically, we will:

1. Use a whitelist of allowed relative paths to validate the `next_page` value. This ensures that only predefined safe paths can be used for redirection.
2. If the `next_page` value is not in the whitelist, we will redirect the user to a default safe page (`items.all_events`).

This approach eliminates the risk of untrusted URL redirection by strictly controlling the allowed redirection targets.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
