### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [ main, master ]
 
+permissions:
+  contents: read
+
 jobs:
   code-quality:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/hveda/mail-scheduler/security/code-scanning/4](https://github.com/hveda/mail-scheduler/security/code-scanning/4)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the minimum required permissions. Since the workflow primarily performs read-only operations (e.g., checking code style, running tests), we will set `contents: read` as the permission. This ensures that the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
