### PR TITLE
Potential fix for code scanning alert no. 1: URL redirection from remote source

### DIFF
--- a/app/auth/views.py
+++ b/app/auth/views.py
@@ -4,6 +4,7 @@ from datetime import datetime, UTC
 from typing import Dict, Any, Union, Optional
 
 from flask import Blueprint, render_template, redirect, url_for, flash, request, current_app
+from werkzeug.urls import url_parse
 from flask.views import MethodView
 from flask_login import login_user, logout_user, login_required, current_user
 from werkzeug.urls import url_parse
@@ -48,9 +49,10 @@ class LoginView(MethodView):
             login_user(user, remember=form.remember_me.data)
             user.update_last_login()
 
-            next_page = request.args.get('next', '')
+            next_page = request.args.get('next', '').replace('\\', '')  # Sanitize input
             allowed_paths = ['/items/all_events', '/items/some_other_page']  # Whitelist of allowed paths
-            if next_page not in allowed_paths:
+            parsed_url = url_parse(next_page)
+            if next_page not in allowed_paths or parsed_url.netloc or parsed_url.scheme:
                 next_page = url_for('items.all_events')  # Default to a safe fallback
 
             return redirect(next_page)


### PR DESCRIPTION
Potential fix for [https://github.com/hveda/mail-scheduler/security/code-scanning/1](https://github.com/hveda/mail-scheduler/security/code-scanning/1)

To fix the issue, we need to ensure that the `next_page` value is both in the whitelist and a safe relative URL. This can be achieved by using the `urlparse` function from Python's `urllib.parse` module to parse the URL and verify that it does not include a scheme or netloc (host name). Additionally, we should sanitize the input to handle backslashes (`\`) and malformed URLs.

Steps to fix:
1. Import `urlparse` from `urllib.parse`.
2. Replace the current validation logic for `next_page` with a check that ensures:
   - The `next_page` value is in the whitelist.
   - The `next_page` value is a relative URL (i.e., it has no scheme or netloc).
3. If the `next_page` value fails validation, default to a safe fallback (`url_for('items.all_events')`).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
