### PR TITLE
Potential fix for code scanning alert no. 1: URL redirection from remote source

### DIFF
--- a/app/auth/views.py
+++ b/app/auth/views.py
@@ -50,9 +50,11 @@ class LoginView(MethodView):
             user.update_last_login()
 
             next_page = request.args.get('next', '').replace('\\', '')  # Sanitize input
-            allowed_paths = ['/items/all_events', '/items/some_other_page']  # Whitelist of allowed paths
-            parsed_url = url_parse(next_page)
-            if next_page not in allowed_paths or parsed_url.netloc or parsed_url.scheme:
+            allowed_paths = [
+                url_for('items.all_events'),
+                url_for('items.some_other_page')
+            ]  # Dynamically generated whitelist of allowed paths
+            if next_page not in allowed_paths:
                 next_page = url_for('items.all_events')  # Default to a safe fallback
 
             return redirect(next_page)


### PR DESCRIPTION
Potential fix for [https://github.com/hveda/mail-scheduler/security/code-scanning/1](https://github.com/hveda/mail-scheduler/security/code-scanning/1)

To fix the issue, we will enhance the validation of the `next_page` variable to ensure it strictly matches the whitelist of allowed paths. Specifically, we will:

1. Use the `url_for` function to generate the allowed paths dynamically, ensuring they are consistent with the application's routing.
2. Compare the sanitized `next_page` value directly against the dynamically generated whitelist.
3. Redirect to a safe fallback (`url_for('items.all_events')`) if the `next_page` value does not match any entry in the whitelist.

This approach ensures that only explicitly allowed paths are used for redirection, eliminating the risk of untrusted URL redirection.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
