### PR TITLE
Potential fix for code scanning alert no. 1: URL redirection from remote source

### DIFF
--- a/app/auth/views.py
+++ b/app/auth/views.py
@@ -50,11 +50,8 @@ class LoginView(MethodView):
             user.update_last_login()
 
             next_page = request.args.get('next', '').replace('\\', '')  # Sanitize input
-            allowed_paths = [
-                url_for('items.all_events'),
-                url_for('items.some_other_page')
-            ]  # Dynamically generated whitelist of allowed paths
-            if next_page not in allowed_paths:
+            parsed_url = url_parse(next_page)
+            if parsed_url.netloc or parsed_url.scheme:  # Ensure it's a relative path
                 next_page = url_for('items.all_events')  # Default to a safe fallback
 
             return redirect(next_page)


### PR DESCRIPTION
Potential fix for [https://github.com/hveda/mail-scheduler/security/code-scanning/1](https://github.com/hveda/mail-scheduler/security/code-scanning/1)

To fix the issue, we will replace the manual whitelist check with a more robust validation mechanism. Specifically, we will use the `url_parse` function from `werkzeug.urls` to ensure that the `next_page` value is a relative path (i.e., it does not include a host or scheme). This approach eliminates the need for a manually maintained whitelist and ensures that only safe, relative paths are allowed.

Steps:
1. Parse the `next_page` value using `url_parse`.
2. Check that the parsed URL has an empty `netloc` and `scheme`, indicating it is a relative path.
3. If the validation fails, default to a safe fallback (`url_for('items.all_events')`).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
