### PR TITLE
Potential fix for code scanning alert no. 1: URL redirection from remote source

### DIFF
--- a/app/auth/views.py
+++ b/app/auth/views.py
@@ -49,9 +49,14 @@ class LoginView(MethodView):
             login_user(user, remember=form.remember_me.data)
             user.update_last_login()
 
+            # Define a whitelist of allowed relative paths
+            allowed_paths = {'/items/all_events', '/profile', '/dashboard'}
+
             next_page = request.args.get('next', '').replace('\\', '')  # Sanitize input
             parsed_url = url_parse(next_page)
-            if parsed_url.netloc or parsed_url.scheme:  # Ensure it's a relative path
+
+            # Validate that the next_page is a relative path and in the whitelist
+            if parsed_url.netloc or parsed_url.scheme or next_page not in allowed_paths:
                 next_page = url_for('items.all_events')  # Default to a safe fallback
 
             return redirect(next_page)


### PR DESCRIPTION
Potential fix for [https://github.com/hveda/mail-scheduler/security/code-scanning/1](https://github.com/hveda/mail-scheduler/security/code-scanning/1)

To fix the issue, we will implement a stricter validation mechanism for the `next_page` redirection target. Specifically, we will maintain a whitelist of allowed relative paths within the application. If the user-provided `next_page` is not in the whitelist, we will redirect to a safe default page (e.g., `'items.all_events'`). This approach ensures that only explicitly allowed paths can be used as redirection targets.

Changes to be made:
1. Define a whitelist of allowed relative paths.
2. Validate the `next_page` value against this whitelist.
3. If the `next_page` is not in the whitelist, redirect to a safe default page.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
