### PR TITLE
Potential fix for code scanning alert no. 1: URL redirection from remote source

### DIFF
--- a/app/auth/views.py
+++ b/app/auth/views.py
@@ -55,6 +55,9 @@ class LoginView(MethodView):
             next_page = request.args.get('next', '').replace('\\', '')  # Sanitize input
             parsed_url = url_parse(next_page)
 
+            # Normalize the path to prevent bypasses through encoding or unexpected characters
+            next_page = parsed_url.path
+
             # Validate that the next_page is a relative path and in the whitelist
             if parsed_url.netloc or parsed_url.scheme or next_page not in allowed_paths:
                 next_page = url_for('items.all_events')  # Default to a safe fallback


### PR DESCRIPTION
Potential fix for [https://github.com/hveda/mail-scheduler/security/code-scanning/1](https://github.com/hveda/mail-scheduler/security/code-scanning/1)

To fix the issue, we will enhance the validation logic for the `next_page` variable. Specifically:
1. Use `url_parse` to ensure that `next_page` is a relative path (i.e., it has no `netloc` or `scheme`).
2. Check that `next_page` is in the whitelist of allowed paths.
3. Add a fallback to a safe default path (`url_for('items.all_events')`) if the validation fails.

Additionally, we will sanitize the `next_page` input by removing backslashes (`\`) and normalizing the path to prevent bypasses through encoding or unexpected characters.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
